### PR TITLE
Report removed selectors in result message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,32 @@
 import {plugin} from 'postcss';
 
-function discardEmpty (node) {
-    const type = node.type;
-    const sub = node.nodes;
-    
-    if (sub) {
-        node.each(discardEmpty);
+function discardAndReport (css, result) {
+    function discardEmpty (node) {
+        const type = node.type;
+        const sub = node.nodes;
+
+        if (sub) {
+            node.each(discardEmpty);
+        }
+
+        if (
+            (type === 'decl' && !node.value) ||
+            (type === 'rule' && !node.selector || sub && !sub.length) ||
+            (type === 'atrule' && (!sub && !node.params || !node.params && !sub.length))
+        ) {
+            node.remove();
+
+            result.messages.push({
+                type: 'removal',
+                plugin: 'postcss-discard-empty',
+                node
+            });
+        }
     }
 
-    if (
-        (type === 'decl' && !node.value) ||
-        (type === 'rule' && !node.selector || sub && !sub.length) ||
-        (type === 'atrule' && (!sub && !node.params || !node.params && !sub.length))
-    ) {
-        node.remove();
-    }
+    css.each(discardEmpty);
 }
 
 export default plugin('postcss-discard-empty', () => {
-    return css => css.each(discardEmpty);
+    return (css, result) => discardAndReport(css, result);
 });


### PR DESCRIPTION
When generating css modules, it's not uncommon for a rule to alias another rule.

```css
.abstractThing {
  font-weight: bold;
}
```
```css
.specificThing {
  composes: abstractThing from './AbstractThing.css'
}
```

In this case, the local name generated for `specificThing` includes the concatenation of the two local names, `-specificThing- -abstractThing-`.

After a `postcss-discard-empty` pass, `.specificThing` is stripped, but the local name lives on.

This PR reports stripped selectors so that they may be consumed further down the chain and used to simplify the local names.